### PR TITLE
Changed Provider version in the Configure the Provider section to the newest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     gns3 = {
       source  = "netopschic/gns3"
-      version = "2.0.0"
+      version = ">=2.5.0"
     }
   }
 }


### PR DESCRIPTION
Through the >= it always chooses the newest version with running `terraform init --upgrade`
```
terraform {
  required_providers {
    gns3 = {
      source  = "netopschic/gns3"
      version = ">=2.5.0"
    }
  }
}
```

