### PR TITLE
Bugfix/qemu console

### DIFF
--- a/provider/resource_qemu_vm.go
+++ b/provider/resource_qemu_vm.go
@@ -139,7 +139,6 @@ func resourceGns3QemuCreate(d *schema.ResourceData, meta interface{}) error {
 		"adapters":     adapters,
 		"bios_image":   biosImage,
 		"cdrom_image":  "",
-		"console_type": consoleType,
 		"ram":          ram,
 		"cpus":         cpus,
 		"platform":     platform,
@@ -164,6 +163,7 @@ func resourceGns3QemuCreate(d *schema.ResourceData, meta interface{}) error {
 		"name":       name,
 		"node_type":  "qemu",
 		"compute_id": "local", // adjust if needed
+		"console_type": consoleType,
 		"properties": properties,
 	}
 
@@ -412,6 +412,9 @@ func resourceGns3QemuUpdate(d *schema.ResourceData, meta interface{}) error {
 	  if v, ok := d.GetOk("console"); ok {
 		putPayload["console"] = v.(int)
 	  }
+    }
+	if d.HasChange("console_type") {
+      putPayload["console_type"] = d.Get("console_type").(string)
     }
 	if d.HasChange("x") {
 		if xv, ok := d.GetOkExists("x"); ok {

--- a/provider/resource_qemu_vm.go
+++ b/provider/resource_qemu_vm.go
@@ -148,9 +148,6 @@ func resourceGns3QemuCreate(d *schema.ResourceData, meta interface{}) error {
 	if cdromImage != nil {
 		properties["cdrom_image"] = cdromImage.(string)
 	}
-	if consoleOk {
-		properties["console"] = consoleVal.(int)
-	}
 	if v, ok := d.GetOk("mac_address"); ok {
 		properties["mac_address"] = v.(string)
 	}
@@ -168,6 +165,10 @@ func resourceGns3QemuCreate(d *schema.ResourceData, meta interface{}) error {
 		"node_type":  "qemu",
 		"compute_id": "local", // adjust if needed
 		"properties": properties,
+	}
+
+	if consoleOk {
+		payload["console"] = consoleVal.(int)
 	}
 
 	// include x/y if explicitly set (even if zero)
@@ -367,16 +368,6 @@ func resourceGns3QemuUpdate(d *schema.ResourceData, meta interface{}) error {
 			delete(props, "cdrom_image")
 		}
 	}
-	if d.HasChange("console") {
-		if v, ok := d.GetOk("console"); ok {
-			props["console"] = v.(int)
-		} else {
-			delete(props, "console")
-		}
-	}
-	if d.HasChange("console_type") {
-		props["console_type"] = d.Get("console_type").(string)
-	}
 	if d.HasChange("cpus") {
 		props["cpus"] = d.Get("cpus").(int)
 	}
@@ -417,6 +408,11 @@ func resourceGns3QemuUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("name") {
 		putPayload["name"] = d.Get("name").(string)
 	}
+	if d.HasChange("console") {
+	  if v, ok := d.GetOk("console"); ok {
+		putPayload["console"] = v.(int)
+	  }
+    }
 	if d.HasChange("x") {
 		if xv, ok := d.GetOkExists("x"); ok {
 			putPayload["x"] = xv.(int)
@@ -427,7 +423,7 @@ func resourceGns3QemuUpdate(d *schema.ResourceData, meta interface{}) error {
 			putPayload["y"] = yv.(int)
 		}
 	}
-
+	
 	// 5) PUT update
 	data, err := json.Marshal(putPayload)
 	if err != nil {


### PR DESCRIPTION
Hey,
it came to my attention that the console and console_type values should be top-level attributes.

Right now we write them under .properties, which works for node creation (GNS3 mirrors them into the top-level on create). However, updating those values later doesn’t seem to work reliably—at least not via script.

A manual API call can update the top-level fields, but then the GUI and the API data end up out of sync. Because of that, I think it makes sense to move console and console_type to top-level attributes (and update them there going forward).

That said, if there was a reason for keeping them in .properties, let me know and I’ll adjust accordingly.

Cheers